### PR TITLE
Arrow Keys now integrated

### DIFF
--- a/Assembler_Source/montador.c
+++ b/Assembler_Source/montador.c
@@ -2723,6 +2723,18 @@ unsigned short RecebeNumero(void)
                 case 'n' :
                     ret = (unsigned short)'\n';
                     break;
+                case 'L' :
+                    ret = (unsigned short) 14;
+                    break;
+                case 'R' :
+                    ret = (unsigned short) 15;
+                    break;
+                case 'U' :
+                    ret = (unsigned short) 16;
+                    break;
+                case 'D' :
+                    ret = (unsigned short) 17;
+                    break;
                 case '0' :
                     ret = (unsigned short)'\0';
                     break;

--- a/Simulator_Source/Controller.cpp
+++ b/Simulator_Source/Controller.cpp
@@ -103,6 +103,23 @@ bool Controller::userInput(const char *tecla)
 		{	reset(); 
 			return TRUE;
 		}
+		else if( !strcmp(tecla, "Left") )
+		{	key = 14;
+			return FALSE;
+		}
+		else if( !strcmp(tecla, "Right") )
+		{	key = 15;
+			return FALSE;
+		}
+		else if( !strcmp(tecla, "Up") )
+		{	key = 16;
+			return FALSE;
+		}
+		else if( !strcmp(tecla, "Down") )
+		{	key = 17;
+			return FALSE;
+		}
+		
 		return FALSE;
 	}
 


### PR DESCRIPTION
I've fully integrated the usage of Arrow Keys by both the Assembler and the Simulator.
When coding ICMC Assembly, you can use '\L', '\R', '\U' and '\D' for the Left, Right, Up and Down keys respectively.
The assembler will generate valid binary code which will then be used by the simulator when these keys are pressed.
