### PR TITLE
Arrumado bug do HALT

### DIFF
--- a/Simulator_Source/Controller.cpp
+++ b/Simulator_Source/Controller.cpp
@@ -12,7 +12,8 @@ Controller::Controller(ModelInterface *model)
 	hex = false;				// comeca decimal
 	automatico = false;	// comeca manual
 	resetVideo = true;	// comeca resetando o video, quando dah reset
-
+	halt = false;		 
+	
 	view = new View(model, this);
 	reset();
 }
@@ -81,7 +82,7 @@ bool Controller::userInput(const char *tecla)
 
 	if( strlen(tecla) > 1)
 	{	if( !strcmp(tecla,"End") )
-		{	if(automatico == false)
+		{	if(automatico == false && halt == false)
 				model->processa();
 			return TRUE;
 		}
@@ -96,11 +97,13 @@ bool Controller::userInput(const char *tecla)
 			return TRUE;
 		}
 		else if( !strcmp(tecla, "Home") )
-		{	switchExecucao(); 
+		{	if(halt == false)
+				switchExecucao();
 			return TRUE;
 		}
 		else if( !strcmp(tecla, "Insert") )
-		{	reset(); 
+		{	reset();
+			halt = false;
 			return TRUE;
 		}
 		else if( !strcmp(tecla, "Left") )
@@ -147,6 +150,7 @@ void Controller::switchExecucao()
 		model->processa();
 		return;
 	}
+
 	view->DestravaRegs();
 	model->setProcessamento(false);
 }
@@ -155,6 +159,13 @@ void Controller::notifyProcessamento()
 { automatico = false;
 	view->DestravaRegs();
 	model->setProcessamento(false);
+}
+
+void Controller::pauseProcessamento()
+{	automatico = false;
+	view->DestravaRegs();
+	model->setProcessamento(false);
+	halt = true;	
 }
 
 void Controller::setResetVideo(bool valor)

--- a/Simulator_Source/Controller.h
+++ b/Simulator_Source/Controller.h
@@ -11,6 +11,7 @@ class Controller : public ControllerInterface
 		ModelInterface *model;
 		bool hex;
 		bool automatico;
+		bool halt;
 		bool resetVideo;
 
 		int key;
@@ -45,6 +46,7 @@ class Controller : public ControllerInterface
 
 
 		void notifyProcessamento();
+		void pauseProcessamento();
 };
 
 #endif

--- a/Simulator_Source/ControllerInterface.h
+++ b/Simulator_Source/ControllerInterface.h
@@ -31,6 +31,7 @@ class ControllerInterface
 		virtual bool getHex() = 0;
 
 		virtual void notifyProcessamento() = 0;
+		virtual void pauseProcessamento() = 0;
 };
 
 #endif

--- a/Simulator_Source/Model.cpp
+++ b/Simulator_Source/Model.cpp
@@ -881,7 +881,7 @@ void Model::processador()
 			break;
 
 		case HALT:
-			controller->notifyProcessamento();
+			controller->pauseProcessamento();
 			break;
 
 		default: break;


### PR DESCRIPTION
## Problema
Durante a execução do simulador, o usuário consegue, através da tecla _**End**_, ler instruções na memória do programa mesmo com a instrução _HALT_ já lida.

## Motivo
Na instrução de controle da entrada do usuário (`Controller:userInput`), a única verificação que é realizada sobre a entrada _**End**_ é com o atributo `automatico`. Isso se torna um problema pois, ao chegar na instrução _HALT_, o método `Model::processador` realiza a chamada do método `Controller:notifyProcessamento`, sendo que este altera o estado de `automatico` para `false`, possibilitando que a entrada _**End**_ seja processada.

## Como foi resolvido
Para evitar várias alterações ao longo do código, a solução mais simples encontrada foi a de adicionar um novo atributo (`halt`) e um novo método (`Controller:pauseProcessamento`) à classe `Controller`. Esse atributo foi utilizado para verificar se a entrada do usuário deveria ser processada ou não. Dessa forma, ao ler a instrução _HALT_, o método `Model::processador` realiza a chamada do método `Controller:pauseProcessamento`, com este alterando `halt` para `true` e impedindo que novas entradas _**End**_ e _**Home**_ sejam processadas. O atributo `halt` volta a ser `false` com a entrada _**Insert**_.

## Testes
Foram utilizados dois arquivos disponíveis no repositório para testar as alterações: _Hello4.mif_ e _Nave11.mif_.
Ambos funcionaram sem problemas, com o problema citado tendo desaparecido.